### PR TITLE
feat: Implement work detail page and update links

### DIFF
--- a/src/components/works/WorkCard.astro
+++ b/src/components/works/WorkCard.astro
@@ -17,13 +17,20 @@ const images = import.meta.glob<{ default: ImageMetadata }>(
 );
 
 // Construct the new href
-const workUrl = `/${lang}/works/${slug.substring(slug.indexOf('/') + 1)}`;
+let actualSlug = slug; // Default to the full slug if no slash is found or slug is invalid
+if (typeof slug === 'string' && slug.includes('/')) {
+  actualSlug = slug.substring(slug.indexOf('/') + 1);
+} else {
+  console.warn(`[WorkCard] Invalid or missing slug for title "${title}". Received: ${slug}`);
+  actualSlug = ''; // Fallback to empty or some other safe default
+}
+const workUrl = `/${lang}/works/${actualSlug}`;
 ---
 
 <div
   class="group cursor-pointer transform transition-all duration-300 hover:scale-105 hover:shadow-xl"
 >
-  <a href={workUrl} class="block" data-astro-prefetch>
+  <a href={actualSlug ? workUrl : `/${lang}/works`} class="block" data-astro-prefetch>
     <!--  作品卡片 -->
     <div
       class="bg-[var(--card-color)] rounded-xl overflow-hidden shadow-lg aspect-square flex flex-col"

--- a/src/components/works/WorkCard.astro
+++ b/src/components/works/WorkCard.astro
@@ -6,20 +6,24 @@ interface Props {
   description?: string;
   cover?: string;
   tags?: string[];
-  href: string;
+  slug: string; // Changed from href
+  lang: string; // Added lang
 }
 
-const { title, description, cover, tags, href } = Astro.props;
+const { title, description, cover, tags, slug, lang } = Astro.props;
 
 const images = import.meta.glob<{ default: ImageMetadata }>(
   "src/assets/works/**/*.{jpeg,jpg,png,gif}"
 );
+
+// Construct the new href
+const workUrl = `/${lang}/works/${slug.substring(slug.indexOf('/') + 1)}`;
 ---
 
 <div
   class="group cursor-pointer transform transition-all duration-300 hover:scale-105 hover:shadow-xl"
 >
-  <a href={href} class="block" data-astro-prefetch>
+  <a href={workUrl} class="block" data-astro-prefetch>
     <!--  作品卡片 -->
     <div
       class="bg-[var(--card-color)] rounded-xl overflow-hidden shadow-lg aspect-square flex flex-col"

--- a/src/pages/[lang]/works/[...slug].astro
+++ b/src/pages/[lang]/works/[...slug].astro
@@ -4,38 +4,60 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import Banner from "@/components/Banner.astro";
 import Markdown from "@/components/Markdown.astro";
 import { getLangFromUrl, useTranslations } from "@/i18n/utils";
-import { ui, defaultLang } from "@/i18n/ui";
+import { ui, defaultLang, languages } from "@/i18n/ui"; // Import languages
 import { Debug } from "astro:components";
 
-
 export async function getStaticPaths() {
-  const works = await getCollection("works", ({ data }) => {
-    return data.draft !== true; // Filter out draft works
-  });
-  return works.map((work) => {
-    // Correctly extract lang and slug.
-    // Example id: "en/my-work.md" -> lang: "en", slug: "my-work"
-    // Example id: "zh-tw/another-work.md" -> lang: "zh-tw", slug: "another-work"
-    const parts = work.id.split("/");
-    const lang = parts[0] as keyof typeof ui;
-    // The slug is the filename without the .md extension
-    const slug = work.slug.substring(work.slug.indexOf('/') + 1);
+  const allWorks = await getCollection("works", ({ data }) => data.draft !== true);
 
-
-    return {
-      params: { lang: lang, slug: slug },
-      props: work,
-    };
+  // Create a set of unique base slugs (e.g., "my-cool-project")
+  const uniqueBaseSlugs = new Set<string>();
+  allWorks.forEach(work => {
+    // Assuming slug is like "en/my-cool-project" or "zh-tw/my-cool-project"
+    const slugParts = work.slug.split('/');
+    if (slugParts.length > 1) {
+      uniqueBaseSlugs.add(slugParts.slice(1).join('/')); // Handles slugs with their own slashes
+    } else {
+      uniqueBaseSlugs.add(work.slug); // Fallback if no lang prefix, though unlikely with current setup
+    }
   });
+
+  const paths = [];
+  for (const baseSlug of uniqueBaseSlugs) {
+    for (const lang of Object.keys(languages) as (keyof typeof ui)[]) {
+      // Try to find the work for the current language and baseSlug
+      let workForPath = allWorks.find(w => w.slug === `${lang}/${baseSlug}`);
+
+      // If not found and the current language is not the default language, try to find it in the default language
+      if (!workForPath && lang !== defaultLang) {
+        workForPath = allWorks.find(w => w.slug === `${defaultLang}/${baseSlug}`);
+      }
+
+      // If a work entry is found (either in the target lang or default lang), create the path
+      if (workForPath) {
+        paths.push({
+          params: { lang, slug: baseSlug }, // URL uses target lang and base slug
+          props: { work: workForPath } // Data comes from the found entry
+        });
+      }
+      // If workForPath is still undefined here, it means the content doesn't exist
+      // for this lang/slug combination, nor in the default language for this baseSlug.
+      // Astro will 404 for these paths if no props are returned, which is fine.
+      // Or more accurately, if this combination is not pushed, Astro won't build it.
+      // We only push paths for which we have content (direct or fallback).
+    }
+  }
+  return paths;
 }
 
-type Props = CollectionEntry<"works">;
+type Props = { work: CollectionEntry<"works"> };
 
-const work = Astro.props;
+const { work } = Astro.props; // work is now the resolved entry (target or fallback)
 const { Content } = await work.render();
 
-const lang = getLangFromUrl(Astro.url);
-const t = useTranslations(lang);
+// The lang for UI translations should be from the URL, not necessarily from work.slug's lang
+const pageLang = getLangFromUrl(Astro.url);
+const t = useTranslations(pageLang);
 ---
 
 <BaseLayout>

--- a/src/pages/[lang]/works/[...slug].astro
+++ b/src/pages/[lang]/works/[...slug].astro
@@ -1,28 +1,50 @@
 ---
-import { getLangFromUrl, useTranslations } from "@/i18n/utils";
 import { getCollection, type CollectionEntry } from "astro:content";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import Banner from "@/components/Banner.astro";
+import Markdown from "@/components/Markdown.astro";
+import { getLangFromUrl, useTranslations } from "@/i18n/utils";
+import { ui, defaultLang } from "@/i18n/ui";
+import { Debug } from "astro:components";
+
 
 export async function getStaticPaths() {
-  const works = await getCollection("works");
-
+  const works = await getCollection("works", ({ data }) => {
+    return data.draft !== true; // Filter out draft works
+  });
   return works.map((work) => {
-    const [lang, ...slugParts] = work.id.split("/");
-    const slug = slugParts.join("/");
+    // Correctly extract lang and slug.
+    // Example id: "en/my-work.md" -> lang: "en", slug: "my-work"
+    // Example id: "zh-tw/another-work.md" -> lang: "zh-tw", slug: "another-work"
+    const parts = work.id.split("/");
+    const lang = parts[0] as keyof typeof ui;
+    // The slug is the filename without the .md extension
+    const slug = work.slug.substring(work.slug.indexOf('/') + 1);
+
 
     return {
-      params: {
-        lang,
-        slug: slug || undefined,
-      },
-      props: { work },
+      params: { lang: lang, slug: slug },
+      props: work,
     };
   });
 }
 
-interface Props {
-  work: CollectionEntry<"works">;
-}
+type Props = CollectionEntry<"works">;
+
+const work = Astro.props;
+const { Content } = await work.render();
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 ---
+
+<BaseLayout>
+  <Banner title={work.data.title} subTitle={work.data.description} bannerImage={work.data.image} />
+  <main class="flex flex-col gap-6 px-6 py-8 lg:gap-8 lg:px-10 lg:py-12">
+    <article class="flex-1">
+      <Markdown>
+        <Content />
+      </Markdown>
+    </article>
+  </main>
+</BaseLayout>

--- a/src/pages/[lang]/works/index.astro
+++ b/src/pages/[lang]/works/index.astro
@@ -60,7 +60,8 @@ works.forEach((work) => {
                 description={work.data.description}
                 cover={work.data.cover}
                 tags={work.data.tags}
-                href={`/${lang}/works/${work.id.replace(`${lang}/`, "")}`}
+                slug={work.slug}
+                lang={lang}
               />
             ))
           }

--- a/src/pages/[lang]/works/index.astro
+++ b/src/pages/[lang]/works/index.astro
@@ -23,21 +23,45 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 
 // 獲取作品集內容
-const allWorks = await getCollection("works");
-const works = allWorks.filter((work) => work.id.startsWith(`${lang}/`));
+const allWorkEntries = await getCollection("works", ({data}) => data.draft !== true); // Ensure drafts are filtered
 
-// 為 banner 動畫準備作品圖片
-const workImages = works.map((work) => ({
-  id: work.id,
+// Identify unique base slugs
+const uniqueBaseSlugs = new Set<string>();
+allWorkEntries.forEach(work => {
+  const slugParts = work.slug.split('/');
+  if (slugParts.length > 1) {
+    uniqueBaseSlugs.add(slugParts.slice(1).join('/'));
+  } else {
+    uniqueBaseSlugs.add(work.slug);
+  }
+});
+
+// For each unique base slug, find the best version to display (current lang or default lang)
+const worksToDisplay = Array.from(uniqueBaseSlugs).map(baseSlug => {
+  let workEntry = allWorkEntries.find(w => w.slug === `${lang}/${baseSlug}`);
+  if (!workEntry && lang !== defaultLang) {
+    workEntry = allWorkEntries.find(w => w.slug === `${defaultLang}/${baseSlug}`);
+  }
+  return workEntry;
+}).filter(work => work !== undefined) as CollectionEntry<"works">[]; // Filter out undefined and assert type
+
+// Sort works, e.g., by date or title if desired (optional)
+// worksToDisplay.sort((a, b) => new Date(b.data.started).getTime() - new Date(a.data.started).getTime());
+
+
+// 為 banner 動畫準備作品圖片 (using worksToDisplay)
+const workImages = worksToDisplay.map((work) => ({
+  id: work.id, // This id will be from the actual entry found (could be defaultLang)
   cover: work.data.cover,
   title: work.data.title,
-  slug: work.id.replace(`${lang}/`, ""),
+  // The slug for banner/navigation purposes should be the base slug, lang is separate
+  slug: work.slug.substring(work.slug.indexOf('/') + 1),
 }));
 
 const images = import.meta.glob<{ default: ImageMetadata }>(
   "src/assets/works/**/*.{jpeg,jpg,png,gif}"
 );
-works.forEach((work) => {
+worksToDisplay.forEach((work) => { // Check images for worksToDisplay
   if (work.data.cover && !images[work.data.cover])
     throw new Error(
       `"${work.data.cover}" does not exist in glob: "src/assets/works/**/*.{jpeg,jpg,png,gif}"`
@@ -54,14 +78,14 @@ works.forEach((work) => {
         <!-- 作品網格 -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {
-            works.map((work) => (
+            worksToDisplay.map((work) => ( // Iterate over worksToDisplay
               <WorkCard
                 title={work.data.title}
                 description={work.data.description}
                 cover={work.data.cover}
                 tags={work.data.tags}
-                slug={work.slug}
-                lang={lang}
+                slug={work.slug} // Pass the full slug of the found entry (e.g., "zh-tw/my-work")
+                lang={lang} // Pass the current page language (e.g., "en")
               />
             ))
           }


### PR DESCRIPTION
- Created a new dynamic page `[lang]/works/[...slug].astro` to display individual work details from markdown files.
- Used existing `BaseLayout`, `Banner`, and `Markdown` components for consistency.
- Implemented `getStaticPaths` to generate pages for all non-draft works.
- Updated `WorkCard.astro` to correctly link to these new detail pages, handling language and slug information.
- Ensured i18n compatibility by correctly parsing language from URLs and using appropriate props.
- Verified changes through code review and data flow analysis.